### PR TITLE
Changes for weeks 51 and 52

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,16 @@ The kana syllabaries also contain variations of the characters. These have diacr
 There is an **additional list of kanji characters** that is defined by its absence. The _hyōgai_ kanji refers to characters that are found in neither the _jōyō_ nor _jinmeiyō_ kanji lists.
 
 This set of kanji characters, if considered in its entirety, contains over 40,000 characters. A reasonable assumption one might make is that, the higher the percentage of _hyōgai_ characters in the subtitles (and thus the overall dialogue), the more adult-orientated an anime series is likely to be.
+
+## Future of the project
+
+_24 December 2025_
+
+While working on the initial code to ingest, parse and clean the raw text from SRT files, I 
+realised that the ingestion logic could be turned into a general library to read in subtitles 
+_safely_. Consequently, I intend to focus more on the ingestion step and turn it into an API 
+that is exposed to users via a Python library. In this way, I hope to maximise the number of 
+people who might benefit from such a tool.
+
+When that happens, I will start a new GitHub repository, copy the ingestion logic over and make 
+this repository private.

--- a/src/dataprep/ingestion.rs
+++ b/src/dataprep/ingestion.rs
@@ -2,7 +2,6 @@
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 
-use crate::dataprep::cleaning::clean_subtitles;
 use anyhow::Result;
 use serde::de::DeserializeOwned;
 use serde_json::from_reader;
@@ -65,7 +64,7 @@ impl TryFrom<&str> for SafeFilePath {
 
         let result: Result<SafeFilePath, PathError> = match fs::canonicalize(&path) {
             Ok(absolute_path) => Ok(SafeFilePath {
-                get_path: (absolute_path),
+                get_path: absolute_path,
             }),
             Err(_) => Err(PathError::FileNotFound),
         };
@@ -83,7 +82,7 @@ impl AsRef<Path> for SafeFilePath {
 
 pub fn ingest_subtitle_file(
     filepath: &str,
-) -> std::result::Result<String, Box<dyn std::error::Error>> {
+) -> std::result::Result<String, Box<dyn Error>> {
     //! Ingests a single subtitle file (i.e. a text file with an `.srt` extension).
     //!
     //! This function checks for file correctness and formats its path into an

--- a/src/dataprep/mod.rs
+++ b/src/dataprep/mod.rs
@@ -1,4 +1,4 @@
 pub mod cleaning;
 pub mod ingestion;
 pub mod processing;
-mod subtitle_set_builder;
+pub mod subtitle_set_builder;

--- a/src/dataprep/subtitle_set_builder.rs
+++ b/src/dataprep/subtitle_set_builder.rs
@@ -5,6 +5,8 @@
 use std::str::FromStr;
 
 const PERMITTED_TIMESTAMP_CHARS: &str = "01234567890:,";
+const U8_MAX_255: usize = u8::MAX as usize;
+const U16_MAX_65535: usize = u16::MAX as usize;
 
 /// One subtitle block in an SRT file.
 ///
@@ -108,26 +110,24 @@ impl FromStr for Timestamp {
             return Err(TimestampError::MalformedTimestamp)
         }
 
-        let u8_max = u8::MAX as usize;
-
         let hours = raw_hh.parse::<usize>().unwrap();
-        if hours > u8_max {
+        if hours > U8_MAX_255 {
             return Err(TimestampError::HoursValueExceeds8BitAllocation)
         }
         let minutes = raw_mm.parse::<usize>().unwrap();
-        if minutes > u8_max {
+        if minutes > U8_MAX_255 {
             return Err(TimestampError::MinutesValueExceeds8BitAllocation)
         } else if minutes > 59 {
             return Err(TimestampError::MinutesValueExceeds59)
         }
         let seconds = raw_ss.parse::<usize>().unwrap();
-        if seconds > u8_max {
+        if seconds > U8_MAX_255 {
             return Err(TimestampError::SecondsValueExceeds8BitAllocation)
         } else if seconds > 59 {
             return Err(TimestampError::SecondsValueExceeds59)
         }
         let milliseconds = raw_ms.parse::<usize>().unwrap();
-        if milliseconds > u16::MAX as usize {
+        if milliseconds > U16_MAX_65535 {
             return Err(TimestampError::MillisecondsValueExceeds16BitAllocation)
         } else if milliseconds > 999 {
             return Err(TimestampError::MillisecondsValueExceeds999)

--- a/src/dataprep/subtitle_set_builder.rs
+++ b/src/dataprep/subtitle_set_builder.rs
@@ -2,13 +2,9 @@
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 
+use crate::types::srt_index::{SrtIndex, SrtIndexError};
+use crate::types::timestamp::{Timestamp, TimestampError};
 use std::str::FromStr;
-
-const PERMITTED_INDEX_CHARS: &str = "0123456789";
-const PERMITTED_TIMESTAMP_CHARS: &str = "0123456789:,";
-const U8_MAX_255: usize = u8::MAX as usize;
-const U16_MAX_65535: usize = u16::MAX as usize;
-const U32_MAX_4294967295: usize = u32::MAX as usize;
 
 /// One subtitle block in an SRT file.
 ///
@@ -20,7 +16,7 @@ const U32_MAX_4294967295: usize = u32::MAX as usize;
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SubtitleUnit {
-    pub index: Index,
+    pub index: SrtIndex,
     pub timing: Timing,
     pub lines: Vec<String>,
 }
@@ -31,148 +27,8 @@ pub struct Timing {
     pub end: Timestamp,
 }
 
-///Rich timestamp representation.
-///Represents `hh:mm:ss,mmm`.
-// Implement the TryFrom trait
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Timestamp {
-    pub hours: u8,
-    pub minutes: u8,
-    pub seconds: u8,
-    pub milliseconds: u16,
-}
-
 /// A full subtitle file, in its logical grouped form.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SubtitleSet {
     pub units: Vec<SubtitleUnit>,
-}
-
-#[derive(Debug)]
-pub enum TimestampError {
-    EmptyMillisecondsValue,
-    EmptySecondsValue,
-    EmptyMinutesValue,
-    EmptyHoursValue,
-
-    MillisecondsValueExceeds999,
-    SecondsValueExceeds59,
-    MinutesValueExceeds59,
-    MillisecondsValueExceeds16BitAllocation,
-    SecondsValueExceeds8BitAllocation,
-    MinutesValueExceeds8BitAllocation,
-    HoursValueExceeds8BitAllocation,
-
-    EmptyString,
-    DisallowedCharacters,
-    NewlineCharDetected,
-    MalformedTimestamp,
-}
-
-impl FromStr for Timestamp {
-    type Err = TimestampError;
-
-    /// Allowed characters in a timestamp are: `01234567890:,`
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        fn count_char_occurrences(xs: &str, x: char) -> usize {
-            xs.chars().filter(|&char| char == x).count()
-        }
-
-        if s.is_empty() {
-            return Err(TimestampError::EmptyString)
-        } else if count_char_occurrences(s, ',') != 1 {
-            return Err(TimestampError::MalformedTimestamp)
-        } else if s.contains("\n") {
-            return Err(TimestampError::NewlineCharDetected)
-        } else if s.chars().all(|char| PERMITTED_TIMESTAMP_CHARS.contains(char)) == false {
-            return Err(TimestampError::DisallowedCharacters)
-        }
-
-        let split_on_comma: Vec<&str> = s.split(",").collect();
-
-        let raw_hh_mm_ss = split_on_comma[0];
-        let split_hh_mm_ss: Vec<&str> = raw_hh_mm_ss.split(":").collect();
-        if split_hh_mm_ss.len() != 3 {
-            return Err(TimestampError::MalformedTimestamp)
-        }
-
-        let raw_hh = split_hh_mm_ss[0];
-        let raw_mm = split_hh_mm_ss[1];
-        let raw_ss = split_hh_mm_ss[2];
-        if raw_hh.is_empty() {
-            return Err(TimestampError::EmptyHoursValue)
-        } else if raw_mm.is_empty() {
-            return Err(TimestampError::EmptyMinutesValue)
-        } else if raw_ss.is_empty() {
-            return Err(TimestampError::EmptySecondsValue)
-        }
-
-        let raw_ms = split_on_comma[1];
-        if raw_ms.is_empty() {
-            return Err(TimestampError::EmptyMillisecondsValue)
-        } else if count_char_occurrences(raw_ms, ':') > 0 {
-            return Err(TimestampError::MalformedTimestamp)
-        }
-
-        let hours = raw_hh.parse::<usize>().unwrap();
-        if hours > U8_MAX_255 {
-            return Err(TimestampError::HoursValueExceeds8BitAllocation)
-        }
-        let minutes = raw_mm.parse::<usize>().unwrap();
-        if minutes > U8_MAX_255 {
-            return Err(TimestampError::MinutesValueExceeds8BitAllocation)
-        } else if minutes > 59 {
-            return Err(TimestampError::MinutesValueExceeds59)
-        }
-        let seconds = raw_ss.parse::<usize>().unwrap();
-        if seconds > U8_MAX_255 {
-            return Err(TimestampError::SecondsValueExceeds8BitAllocation)
-        } else if seconds > 59 {
-            return Err(TimestampError::SecondsValueExceeds59)
-        }
-        let milliseconds = raw_ms.parse::<usize>().unwrap();
-        if milliseconds > U16_MAX_65535 {
-            return Err(TimestampError::MillisecondsValueExceeds16BitAllocation)
-        } else if milliseconds > 999 {
-            return Err(TimestampError::MillisecondsValueExceeds999)
-        }
-
-        Ok(
-            Timestamp{
-                hours: hours as u8,
-                minutes: minutes as u8,
-                seconds: seconds as u8,
-                milliseconds: milliseconds as u16
-            }
-        )
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Index(u32);
-
-#[derive(Debug)]
-pub enum IndexError {
-    EmptyIndex,
-    IndexExceedsMaxU32Size,
-    IndexContainsDisallowedChars
-}
-
-impl FromStr for Index {
-    type Err = IndexError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.is_empty() {
-            return Err(IndexError::EmptyIndex)
-        } else if s.chars().all(|char| PERMITTED_INDEX_CHARS.contains(char)) == false {
-            return Err(IndexError::IndexContainsDisallowedChars)
-        }
-
-        let parsed_index = s.parse::<usize>().unwrap();
-        if parsed_index > U32_MAX_4294967295 {
-            return Err(IndexError::IndexExceedsMaxU32Size)
-        }
-
-        Ok(Index(parsed_index as u32))
-    }
 }

--- a/src/dataprep/subtitle_set_builder.rs
+++ b/src/dataprep/subtitle_set_builder.rs
@@ -20,7 +20,7 @@ const U32_MAX_4294967295: usize = u32::MAX as usize;
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SubtitleUnit {
-    pub index: u32,
+    pub index: Index,
     pub timing: Timing,
     pub lines: Vec<String>,
 }

--- a/src/dataprep/subtitle_set_builder.rs
+++ b/src/dataprep/subtitle_set_builder.rs
@@ -2,6 +2,10 @@
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 
+use std::str::FromStr;
+
+const PERMITTED_TIMESTAMP_CHARS: &str = "01234567890:,";
+
 /// One subtitle block in an SRT file.
 ///
 /// ```text
@@ -38,4 +42,104 @@ pub struct Timestamp {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SubtitleSet {
     pub units: Vec<SubtitleUnit>,
+}
+
+#[derive(Debug)]
+pub enum TimestampError {
+    EmptyMillisecondsValue,
+    EmptySecondsValue,
+    EmptyMinutesValue,
+    EmptyHoursValue,
+    MillisecondsValueExceeds999,
+    SecondsValueExceeds59,
+    MinutesValueExceeds59,
+    MillisecondsValueExceeds16BitAllocation,
+    SecondsValueExceeds8BitAllocation,
+    MinutesValueExceeds8BitAllocation,
+    HoursValueExceeds8BitAllocation,
+    EmptyString,
+    DisallowedCharacters,
+    NewlineCharDetected,
+    MalformedTimestamp,
+}
+
+impl FromStr for Timestamp {
+    type Err = TimestampError;
+
+    /// Allowed characters in a timestamp are: `01234567890:,`
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        fn count_char_occurrences(xs: &str, x: char) -> usize {
+            xs.chars().filter(|&char| char == x).count()
+        }
+
+        if s.is_empty() {
+            return Err(TimestampError::EmptyString)
+        } else if count_char_occurrences(s, ',') != 1 {
+            return Err(TimestampError::MalformedTimestamp)
+        } else if s.contains("\n") {
+            return Err(TimestampError::NewlineCharDetected)
+        } else if s.chars().all(|char| PERMITTED_TIMESTAMP_CHARS.contains(char)) == false {
+            return Err(TimestampError::DisallowedCharacters)
+        }
+
+        let split_on_comma: Vec<&str> = s.split(",").collect();
+
+        let raw_hh_mm_ss = split_on_comma[0];
+        let split_hh_mm_ss: Vec<&str> = raw_hh_mm_ss.split(":").collect();
+        if split_hh_mm_ss.len() != 3 {
+            return Err(TimestampError::MalformedTimestamp)
+        }
+
+        let raw_hh = split_hh_mm_ss[0];
+        let raw_mm = split_hh_mm_ss[1];
+        let raw_ss = split_hh_mm_ss[2];
+        if raw_hh.is_empty() {
+            return Err(TimestampError::EmptyHoursValue)
+        } else if raw_mm.is_empty() {
+            return Err(TimestampError::EmptyMinutesValue)
+        } else if raw_ss.is_empty() {
+            return Err(TimestampError::EmptySecondsValue)
+        }
+
+        let raw_ms = split_on_comma[1];
+        if raw_ms.is_empty() {
+            return Err(TimestampError::EmptyMillisecondsValue)
+        } else if count_char_occurrences(raw_ms, ':') > 0 {
+            return Err(TimestampError::MalformedTimestamp)
+        }
+
+        let u8_max = u8::MAX as usize;
+
+        let hours = raw_hh.parse::<usize>().unwrap();
+        if hours > u8_max {
+            return Err(TimestampError::HoursValueExceeds8BitAllocation)
+        }
+        let minutes = raw_mm.parse::<usize>().unwrap();
+        if minutes > u8_max {
+            return Err(TimestampError::MinutesValueExceeds8BitAllocation)
+        } else if minutes > 59 {
+            return Err(TimestampError::MinutesValueExceeds59)
+        }
+        let seconds = raw_ss.parse::<usize>().unwrap();
+        if seconds > u8_max {
+            return Err(TimestampError::SecondsValueExceeds8BitAllocation)
+        } else if seconds > 59 {
+            return Err(TimestampError::SecondsValueExceeds59)
+        }
+        let milliseconds = raw_ms.parse::<usize>().unwrap();
+        if milliseconds > u16::MAX as usize {
+            return Err(TimestampError::MillisecondsValueExceeds16BitAllocation)
+        } else if milliseconds > 999 {
+            return Err(TimestampError::MillisecondsValueExceeds999)
+        }
+
+        Ok(
+            Timestamp{
+                hours: hours as u8,
+                minutes: minutes as u8,
+                seconds: seconds as u8,
+                milliseconds: milliseconds as u16
+            }
+        )
+    }
 }

--- a/src/dataprep/subtitle_set_builder.rs
+++ b/src/dataprep/subtitle_set_builder.rs
@@ -4,9 +4,11 @@
 
 use std::str::FromStr;
 
-const PERMITTED_TIMESTAMP_CHARS: &str = "01234567890:,";
+const PERMITTED_INDEX_CHARS: &str = "0123456789";
+const PERMITTED_TIMESTAMP_CHARS: &str = "0123456789:,";
 const U8_MAX_255: usize = u8::MAX as usize;
 const U16_MAX_65535: usize = u16::MAX as usize;
+const U32_MAX_4294967295: usize = u32::MAX as usize;
 
 /// One subtitle block in an SRT file.
 ///
@@ -52,6 +54,7 @@ pub enum TimestampError {
     EmptySecondsValue,
     EmptyMinutesValue,
     EmptyHoursValue,
+
     MillisecondsValueExceeds999,
     SecondsValueExceeds59,
     MinutesValueExceeds59,
@@ -59,6 +62,7 @@ pub enum TimestampError {
     SecondsValueExceeds8BitAllocation,
     MinutesValueExceeds8BitAllocation,
     HoursValueExceeds8BitAllocation,
+
     EmptyString,
     DisallowedCharacters,
     NewlineCharDetected,
@@ -141,5 +145,34 @@ impl FromStr for Timestamp {
                 milliseconds: milliseconds as u16
             }
         )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Index(u32);
+
+#[derive(Debug)]
+pub enum IndexError {
+    EmptyIndex,
+    IndexExceedsMaxU32Size,
+    IndexContainsDisallowedChars
+}
+
+impl FromStr for Index {
+    type Err = IndexError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err(IndexError::EmptyIndex)
+        } else if s.chars().all(|char| PERMITTED_INDEX_CHARS.contains(char)) == false {
+            return Err(IndexError::IndexContainsDisallowedChars)
+        }
+
+        let parsed_index = s.parse::<usize>().unwrap();
+        if parsed_index > U32_MAX_4294967295 {
+            return Err(IndexError::IndexExceedsMaxU32Size)
+        }
+
+        Ok(Index(parsed_index as u32))
     }
 }

--- a/src/dataprep/subtitle_set_builder.rs
+++ b/src/dataprep/subtitle_set_builder.rs
@@ -4,6 +4,7 @@
 
 use crate::types::srt_index::{SrtIndex, SrtIndexError};
 use crate::types::timestamp::{Timestamp, TimestampError};
+use crate::types::timing::{Timing, TimingError};
 use std::str::FromStr;
 
 /// One subtitle block in an SRT file.
@@ -19,12 +20,6 @@ pub struct SubtitleUnit {
     pub index: SrtIndex,
     pub timing: Timing,
     pub lines: Vec<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Timing {
-    pub start: Timestamp,
-    pub end: Timestamp,
 }
 
 /// A full subtitle file, in its logical grouped form.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 #![allow(unused_variables)]
 
 mod dataprep;
+mod types;
 
 use dataprep::cleaning::{clean_subtitles, helper_dedupe_and_sort};
 use dataprep::ingestion::ingest_subtitle_file;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,0 +1,2 @@
+pub mod srt_index;
+pub mod timestamp;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,2 +1,3 @@
 pub mod srt_index;
 pub mod timestamp;
+pub mod timing;

--- a/src/types/srt_index.rs
+++ b/src/types/srt_index.rs
@@ -5,7 +5,10 @@ const U32_MAX_4294967295: usize = u32::MAX as usize;
 
 /// Within an `.srt` file, when reading from top to bottom, instances of
 /// `SrtIndex` must be monotonic increasing and the value of each increase
-/// in step should be `1`, otherwise the subtitle file is not well formed.
+/// in step should be `1`, otherwise the subtitle file is not well-formed.
+///
+/// From the definition of [`PERMITTED_INDEX_CHARS`], it is implicitly
+/// expected that a subtitle file’s indices are non-negative.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SrtIndex(u32);
 

--- a/src/types/srt_index.rs
+++ b/src/types/srt_index.rs
@@ -1,0 +1,36 @@
+use std::str::FromStr;
+
+const PERMITTED_INDEX_CHARS: &str = "0123456789";
+const U32_MAX_4294967295: usize = u32::MAX as usize;
+
+/// Within an `.srt` file, when reading from top to bottom, instances of
+/// `SrtIndex` must be monotonic increasing and the value of each increase
+/// in step should be `1`, otherwise the subtitle file is not well formed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SrtIndex(u32);
+
+#[derive(Debug)]
+pub enum SrtIndexError {
+    EmptyIndex,
+    IndexExceedsMaxU32Size,
+    IndexContainsDisallowedChars
+}
+
+impl FromStr for SrtIndex {
+    type Err = SrtIndexError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err(SrtIndexError::EmptyIndex)
+        } else if s.chars().all(|char| PERMITTED_INDEX_CHARS.contains(char)) == false {
+            return Err(SrtIndexError::IndexContainsDisallowedChars)
+        }
+
+        let parsed_index = s.parse::<usize>().unwrap();
+        if parsed_index > U32_MAX_4294967295 {
+            return Err(SrtIndexError::IndexExceedsMaxU32Size)
+        }
+
+        Ok(SrtIndex(parsed_index as u32))
+    }
+}

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -1,0 +1,115 @@
+use std::str::FromStr;
+
+const PERMITTED_TIMESTAMP_CHARS: &str = "0123456789:,";
+const U8_MAX_255: usize = u8::MAX as usize;
+const U16_MAX_65535: usize = u16::MAX as usize;
+
+///Rich timestamp representation.
+///Represents `hh:mm:ss,mmm`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Timestamp {
+    pub hours: u8,
+    pub minutes: u8,
+    pub seconds: u8,
+    pub milliseconds: u16,
+}
+
+#[derive(Debug)]
+pub enum TimestampError {
+    EmptyMillisecondsValue,
+    EmptySecondsValue,
+    EmptyMinutesValue,
+    EmptyHoursValue,
+
+    MillisecondsValueExceeds999,
+    SecondsValueExceeds59,
+    MinutesValueExceeds59,
+    MillisecondsValueExceeds16BitAllocation,
+    SecondsValueExceeds8BitAllocation,
+    MinutesValueExceeds8BitAllocation,
+    HoursValueExceeds8BitAllocation,
+
+    EmptyString,
+    DisallowedCharacters,
+    NewlineCharDetected,
+    MalformedTimestamp,
+}
+
+impl FromStr for Timestamp {
+    type Err = TimestampError;
+
+    /// Allowed characters in a timestamp are: `01234567890:,`
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        fn count_char_occurrences(xs: &str, x: char) -> usize {
+            xs.chars().filter(|&char| char == x).count()
+        }
+
+        if s.is_empty() {
+            return Err(TimestampError::EmptyString)
+        } else if count_char_occurrences(s, ',') != 1 {
+            return Err(TimestampError::MalformedTimestamp)
+        } else if s.contains("\n") {
+            return Err(TimestampError::NewlineCharDetected)
+        } else if s.chars().all(|char| PERMITTED_TIMESTAMP_CHARS.contains(char)) == false {
+            return Err(TimestampError::DisallowedCharacters)
+        }
+
+        let split_on_comma: Vec<&str> = s.split(",").collect();
+
+        let raw_hh_mm_ss = split_on_comma[0];
+        let split_hh_mm_ss: Vec<&str> = raw_hh_mm_ss.split(":").collect();
+        if split_hh_mm_ss.len() != 3 {
+            return Err(TimestampError::MalformedTimestamp)
+        }
+
+        let raw_hh = split_hh_mm_ss[0];
+        let raw_mm = split_hh_mm_ss[1];
+        let raw_ss = split_hh_mm_ss[2];
+        if raw_hh.is_empty() {
+            return Err(TimestampError::EmptyHoursValue)
+        } else if raw_mm.is_empty() {
+            return Err(TimestampError::EmptyMinutesValue)
+        } else if raw_ss.is_empty() {
+            return Err(TimestampError::EmptySecondsValue)
+        }
+
+        let raw_ms = split_on_comma[1];
+        if raw_ms.is_empty() {
+            return Err(TimestampError::EmptyMillisecondsValue)
+        } else if count_char_occurrences(raw_ms, ':') > 0 {
+            return Err(TimestampError::MalformedTimestamp)
+        }
+
+        let hours = raw_hh.parse::<usize>().unwrap();
+        if hours > U8_MAX_255 {
+            return Err(TimestampError::HoursValueExceeds8BitAllocation)
+        }
+        let minutes = raw_mm.parse::<usize>().unwrap();
+        if minutes > U8_MAX_255 {
+            return Err(TimestampError::MinutesValueExceeds8BitAllocation)
+        } else if minutes > 59 {
+            return Err(TimestampError::MinutesValueExceeds59)
+        }
+        let seconds = raw_ss.parse::<usize>().unwrap();
+        if seconds > U8_MAX_255 {
+            return Err(TimestampError::SecondsValueExceeds8BitAllocation)
+        } else if seconds > 59 {
+            return Err(TimestampError::SecondsValueExceeds59)
+        }
+        let milliseconds = raw_ms.parse::<usize>().unwrap();
+        if milliseconds > U16_MAX_65535 {
+            return Err(TimestampError::MillisecondsValueExceeds16BitAllocation)
+        } else if milliseconds > 999 {
+            return Err(TimestampError::MillisecondsValueExceeds999)
+        }
+
+        Ok(
+            Timestamp{
+                hours: hours as u8,
+                minutes: minutes as u8,
+                seconds: seconds as u8,
+                milliseconds: milliseconds as u16
+            }
+        )
+    }
+}

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -20,6 +20,14 @@ pub enum TimestampError {
     MalformedTimestamp(String),
 }
 
+impl TimestampError {
+    fn malformed(msg: &str, original_input: &str) -> Self {
+        TimestampError::MalformedTimestamp(
+            format!("{} (input string: {})", msg, original_input)
+        )
+    }
+}
+
 impl FromStr for Timestamp {
     type Err = TimestampError;
 
@@ -32,14 +40,11 @@ impl FromStr for Timestamp {
         if s.is_empty() {
             return Err(TimestampError::EmptyString)
         } else if count_char_occurrences(s, ',') != 1 {
-            println!("Regarding timestamp string: {}", s);
-            return Err(TimestampError::MalformedTimestamp(String::from("Timestamp string must have one, and only one, comma as a millisecond separator")))
+            return Err(TimestampError::malformed("Timestamp string can’t have more than one comma as a millisecond separator", s))
         } else if s.contains("\n") {
-            println!("Regarding timestamp string: {}", s);
-            return Err(TimestampError::MalformedTimestamp(String::from("Illegal newline character detected")))
+            return Err(TimestampError::malformed("Timestamp string cannot contain newlines", s))
         } else if s.chars().all(|char| PERMITTED_TIMESTAMP_CHARS.contains(char)) == false {
-            println!("Regarding timestamp string: {}", s);
-            return Err(TimestampError::MalformedTimestamp(String::from("Illegal characters detected; allowed characters are 0123456789:,")))
+            return Err(TimestampError::malformed("Illegal characters detected; allowed characters are 0123456789:,", s))
         }
 
         // First element of vector: HH:MM:SS
@@ -49,61 +54,49 @@ impl FromStr for Timestamp {
         let raw_hh_mm_ss = split_on_comma[0];
         let split_hh_mm_ss: Vec<&str> = raw_hh_mm_ss.split(":").collect();
         if split_hh_mm_ss.len() != 3 {
-            println!("Regarding timestamp string: {}", s);
-            return Err(TimestampError::MalformedTimestamp(String::from("Timestamp must have properly defined HH:MM:SS component")))
+            return Err(TimestampError::malformed("Timestamp must have properly defined HH:MM:SS component", s))
         }
 
         let raw_hh = split_hh_mm_ss[0];
         let raw_mm = split_hh_mm_ss[1];
         let raw_ss = split_hh_mm_ss[2];
         if raw_hh.is_empty() {
-            println!("Regarding timestamp string: {}", s);
-            return Err(TimestampError::MalformedTimestamp(String::from("Empty hours value in HH:MM:SS")))
+            return Err(TimestampError::malformed("Empty hours value in HH:MM:SS", s))
         } else if raw_mm.is_empty() {
-            println!("Regarding timestamp string: {}", s);
-            return Err(TimestampError::MalformedTimestamp(String::from("Empty minutes value in HH:MM:SS")))
+            return Err(TimestampError::malformed("Empty minutes value in HH:MM:SS", s))
         } else if raw_ss.is_empty() {
-            println!("Regarding timestamp string: {}", s);
-            return Err(TimestampError::MalformedTimestamp(String::from("Empty seconds value in HH:MM:SS")))
+            return Err(TimestampError::malformed("Empty seconds value in HH:MM:SS", s))
         }
 
         let raw_ms = split_on_comma[1];
         if raw_ms.is_empty() {
-            println!("Regarding timestamp string: {}", s);
-            return Err(TimestampError::MalformedTimestamp(String::from("Empty milliseconds value")))
+            return Err(TimestampError::malformed("Empty milliseconds value", s))
         } else if count_char_occurrences(raw_ms, ':') > 0 {
-            println!("Regarding timestamp string: {}", s);
-            return Err(TimestampError::MalformedTimestamp(String::from("Milliseconds component contains illegal colon character")))
+            return Err(TimestampError::malformed("Milliseconds component contains illegal colon character", s))
         }
 
         let hours = raw_hh.parse::<usize>().unwrap();
-        if hours > U8_MAX_255 { // Should I increase the allocation to u16? 255 hours may be exceeded in very rare cases
-            println!("Regarding timestamp string: {}", s);
-            return Err(TimestampError::MalformedTimestamp(String::from("Hours value exceeds maximum unsigned 8-bit value of 255")))
+        if hours > U8_MAX_255 { // Should I increase the allocation to u16?
+            return Err(TimestampError::malformed("Hours value exceeds maximum unsigned 8-bit value of 255", s))
         }
         let minutes = raw_mm.parse::<usize>().unwrap();
         if minutes > U8_MAX_255 {
-            println!("Regarding timestamp string: {}", s);
-            return Err(TimestampError::MalformedTimestamp(String::from("Minutes value exceeds maximum unsigned 8-bit value of 255")))
+            return Err(TimestampError::malformed("Minutes value exceeds maximum unsigned 8-bit value of 255", s))
         } else if minutes > 59 {
-            println!("Regarding timestamp string: {}", s);
-            return Err(TimestampError::MalformedTimestamp(String::from("Minutes value exceeds 59")))
+            return Err(TimestampError::malformed("Minutes value exceeds 59", s))
         }
         let seconds = raw_ss.parse::<usize>().unwrap();
         if seconds > U8_MAX_255 {
-            println!("Regarding timestamp string: {}", s);
-            return Err(TimestampError::MalformedTimestamp(String::from("Seconds value exceeds maximum unsigned 8-bit value of 255")))
+            return Err(TimestampError::malformed("Seconds value exceeds maximum unsigned 8-bit value of 255", s))
         } else if seconds > 59 {
-            println!("Regarding timestamp string: {}", s);
-            return Err(TimestampError::MalformedTimestamp(String::from("Seconds value exceeds 59")))
+            return Err(TimestampError::malformed("Seconds value exceeds 59", s))
         }
         let milliseconds = raw_ms.parse::<usize>().unwrap();
         if milliseconds > U16_MAX_65535 {
             println!("Regarding timestamp string: {}", s);
-            return Err(TimestampError::MalformedTimestamp(String::from("Milliseconds value exceeds maximum unsigned 16-bit value of 65535")))
+            return Err(TimestampError::malformed("Milliseconds value exceeds maximum unsigned 16-bit value of 65535", s))
         } else if milliseconds > 999 {
-            println!("Regarding timestamp string: {}", s);
-            return Err(TimestampError::MalformedTimestamp(String::from("Milliseconds value exceeds 999")))
+            return Err(TimestampError::malformed("Milliseconds value exceeds 999", s))
         }
 
         Ok(

--- a/src/types/timing.rs
+++ b/src/types/timing.rs
@@ -23,6 +23,9 @@ pub enum TimingError {
 }
 
 impl From<TimestampError> for TimingError {
+    // This allows me to convert a `TimestampError` to a `TimingError` using the `parse` function. Although
+    // there is no explicit use of the `from` function, the `?` operator implicitly applies `from` when
+    // dealing with the error branch (parsing returns a `Result` type).
     fn from(error: TimestampError) -> Self {
         TimingError::Timestamp(error)
     }

--- a/src/types/timing.rs
+++ b/src/types/timing.rs
@@ -1,0 +1,59 @@
+use std::str::FromStr;
+use crate::types::timestamp;
+use crate::types::timestamp::{Timestamp, TimestampError};
+
+const TIMING_SEPARATOR: &str = "-->";
+
+/// An instance of `Timing` is expected to have one, and only one, separator
+/// and exactly two [`Timestamp`] instances: one to indicate when a subtitle
+/// appears on the screen and another to indicate when it disappears.
+///
+/// A `Timing` separator looks as follows: `-->`
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Timing {
+    pub start: Timestamp,
+    pub end: Timestamp,
+}
+
+#[derive(Debug)]
+pub enum TimingError {
+    EmptyTiming,
+    NoTimestampSeparator,
+    MultipleTimestampSeparators,
+    Timestamp(TimestampError),
+}
+
+impl From<TimestampError> for TimingError {
+    fn from(error: TimestampError) -> Self {
+        TimingError::Timestamp(error)
+    }
+}
+
+impl FromStr for Timing {
+    type Err = TimingError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err(TimingError::EmptyTiming)
+        }
+
+        let split_s = s.split(TIMING_SEPARATOR);  // This is an iterator
+        let split_s_elems = split_s.clone().count();
+
+        if split_s_elems == 1 {
+            return Err(TimingError::NoTimestampSeparator)
+        } else if split_s_elems > 2 {
+            return Err(TimingError::MultipleTimestampSeparators)
+        }
+
+        let split_s_clone: Vec<&str> = split_s.clone().collect();
+
+        let start_raw: &str = split_s_clone[0].trim();
+        let start_timestamp = start_raw.parse::<Timestamp>()?;
+
+        let end_raw: &str = split_s_clone[1].trim();
+        let end_timestamp = end_raw.parse::<Timestamp>()?;
+
+        Ok(Timing{start: start_timestamp, end: end_timestamp})
+    }
+}

--- a/src/types/timing.rs
+++ b/src/types/timing.rs
@@ -18,8 +18,7 @@ pub struct Timing {
 #[derive(Debug)]
 pub enum TimingError {
     EmptyTiming,
-    NoTimestampSeparator,
-    MultipleTimestampSeparators,
+    MalformedTiming(String),
     Timestamp(TimestampError),
 }
 
@@ -32,6 +31,8 @@ impl From<TimestampError> for TimingError {
 impl FromStr for Timing {
     type Err = TimingError;
 
+    // TODO: there needs to be a comparison logic between the first and second timestamps. If the first timestamp has
+    // a larger value than the second one, then we must return an error.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.is_empty() {
             return Err(TimingError::EmptyTiming)
@@ -41,9 +42,11 @@ impl FromStr for Timing {
         let split_s_elems = split_s.clone().count();
 
         if split_s_elems == 1 {
-            return Err(TimingError::NoTimestampSeparator)
+            println!("Regarding timing: {}", s);
+            return Err(TimingError::MalformedTiming(String::from("Missing timestamp separator (-->)")))
         } else if split_s_elems > 2 {
-            return Err(TimingError::MultipleTimestampSeparators)
+            println!("Regarding timing: {}", s);
+            return Err(TimingError::MalformedTiming(String::from("Multiple timestamp separators")))
         }
 
         let split_s_clone: Vec<&str> = split_s.clone().collect();

--- a/src/types/timing.rs
+++ b/src/types/timing.rs
@@ -42,10 +42,10 @@ impl FromStr for Timing {
         let split_s_elems = split_s.clone().count();
 
         if split_s_elems == 1 {
-            println!("Regarding timing: {}", s);
+            println!("Regarding timing string: {}", s);
             return Err(TimingError::MalformedTiming(String::from("Missing timestamp separator (-->)")))
         } else if split_s_elems > 2 {
-            println!("Regarding timing: {}", s);
+            println!("Regarding timing string: {}", s);
             return Err(TimingError::MalformedTiming(String::from("Multiple timestamp separators")))
         }
 


### PR DESCRIPTION
The chronology of changes is in _ascending_ order. Scroll down for newer commits.

## The `Timestamp` type

### [Parse into `Timestamp` type](https://github.com/iankohdes/examining-one-anime-episodes-subtitles/pull/15/commits/788ca8461afaedf3288e985c7c783d899e90fbf8)

- I’ve decided to adopt your approach and implement traits on the most granular types, starting with `Timestamp`
- I came up with 15 different error values for `TimestampError` (not sure if this is overkill)

### [Create meaningful integer limits](https://github.com/iankohdes/examining-one-anime-episodes-subtitles/pull/15/commits/fddc661d1d4b42579b2c0792ae4b5278218da288)

- The previous commit (above) tested whether user input exceeded the maximum values for the `u8` and `u16` integer types, but didn’t actually explicitly mention what those maximum values are
- This small commit bakes the values into the names of constants, so future viewers don’t have to look up what they are
- The constants continue to be of `usize` type to anticipate any extremely large values that users mistakenly input to the parsing function

## Add `Index` newtype

- Commits:
    - [Initial](https://github.com/iankohdes/examining-one-anime-episodes-subtitles/pull/15/commits/7e3c8ff90a46b0daff28d32f2a067a46a9c67128)
    - [Follow-up](https://github.com/iankohdes/examining-one-anime-episodes-subtitles/pull/15/commits/d2ee23c744ce5b309b2b90a2f62ce56fc70ebc26)
- I decided to make the index its own newtype so that I could bake the correctness checks into the `from_str` function
- This makes parsing consistent with the procedure for the `Timestamp` type

## [Reorganise project and move custom types into dedicated directory](https://github.com/iankohdes/examining-one-anime-episodes-subtitles/pull/15/commits/78d5b132062c7632aeaf785d556472ab2e4a83aa)

- This commit creates a `types` directory to ensure that the code in the `dataprep` directory only focuses on preparing the input data, not creating types to deal with said data
- Every custom type gets its own file
- Currently, `subtitle_set_builder.rs` remains in the `dataprep` directory, but it will eventually be moved to the `types` directory and renamed to `subtitle_set.rs` to be consistent with the other types

## [Build the `Timing` type](https://github.com/iankohdes/examining-one-anime-episodes-subtitles/pull/15/commits/f8f4d35ed4987ff42565f50fcc67d469f394dcf8)

- This is the first custom type that contains another custom type (`Timestamp`)
- **Note to future self:** to bubble up errors from one custom type to another, there need to be three changes to the code:
    - In the outer type’s error enum (in this case `TimingError`), add another value to store the inner type’s error type (in this case `TimestampError`): `Timestamp(TimestampError)` for example
    - Add an `impl` block for the `From` trait for `TimingError`: `impl From<TimestampError> for TimingError`
    - Use the `?` operator to automagically handle the error and return a `Timestamp` (or inner) error where appropriate

## [Streamline error enum values](https://github.com/iankohdes/examining-one-anime-episodes-subtitles/pull/15/commits/f00c0383ae949fe1f156cd79fe211063988396cb)

- For the `Timestamp` type, reduce the number of possible values in the enum
- Move the nuanced information regarding specific errors into strings inside the `MalformedTimestamp` value
- Before displaying the error message, print the offending timestamp string for users’ convenience (no need to scour the whole SRT file to find the specific formatting error)