### PR TITLE
Implement Display trait for errors

### DIFF
--- a/src/dataprep/parser_alt.rs
+++ b/src/dataprep/parser_alt.rs
@@ -50,7 +50,6 @@ pub enum ParserError {
 
 impl Display for ParserError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        // write!(f, "Something bad happened")
         match self {
             ParserError::ReadError(filename) => {
                 write!(f, "Error while reading file: {filename}")
@@ -59,18 +58,16 @@ impl Display for ParserError {
                 write!(f, "Some illegal input received: {msg}")
             }
             ParserError::IndexParseError(msg) => {
-                write!(f, "Incorrect format of subtitle index: {msg:?}")  // Debug printing option to avoid having to implement Display and Error; not advisable for production code
+                write!(f, "Incorrect format of subtitle index: {msg}")
             }
             ParserError::TimingParseError(msg) => {
-                write!(f, "Incorrect format of timestamp(s): {msg:?}")
+                write!(f, "Incorrect format of timestamp(s): {msg}")
             }
         }
     }
 }
 
-impl Error for ParserError {
-
-}
+impl Error for ParserError {}
 
 impl From<SrtIndexError> for ParserError {
     fn from(err: SrtIndexError) -> Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use crate::dataprep::ingestion::SafeFilePath;
 // PARSER
 use dataprep::parser_alt::{Parser};
 use crate::types::timestamp::{Timestamp, TimestampError};
+use crate::types::timing::{Timing, TimingError};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // We need this SafeFilePath -> File -> BufReader chain because:
@@ -38,11 +39,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // println!("{:?}", parsed_data);
 
-    let x = "00:01:14,324";
-    let timestamp_x = x.parse::<Timestamp>();
-    match timestamp_x {
-        Ok(s) => { println!("{s}"); }
-        Err(e) => { println!("{e}"); }
+    let x = "00:01:14,324 --> 00:01:85,145";
+    let timing_x = x.parse::<Timing>();
+    match timing_x {
+        Ok(s) => {println!("{s}")}
+        Err(s) => {println!("{s}")}
     }
 
     // let mut parser = SubtitleParser::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,23 +5,16 @@
 mod dataprep;
 mod types;
 
-use dataprep::cleaning::{clean_subtitles, helper_dedupe_and_sort};
-use dataprep::parser::SubtitleParser;
 use serde::Deserialize;
-use std::collections::{BTreeSet, HashMap};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::str::FromStr;
-use std::{env, fs};
 
 use crate::dataprep::ingestion::SafeFilePath;
-use crate::types::subtitle_unit::SubtitleUnit;
-use crate::types::srt_index::SrtIndex;
-use crate::types::timing::Timing;
 
 // PARSER
 use dataprep::parser_alt::{Parser};
-use crate::dataprep::parser_alt;
+use crate::types::timestamp::{Timestamp, TimestampError};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // We need this SafeFilePath -> File -> BufReader chain because:
@@ -43,7 +36,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let lines = reader.lines();
     let parsed_data = Parser::parse(lines)?;
 
-    println!("{:?}", parsed_data);
+    // println!("{:?}", parsed_data);
+
+    let x = "00:01:14,324";
+    let timestamp_x = x.parse::<Timestamp>();
+    match timestamp_x {
+        Ok(s) => { println!("{s}"); }
+        Err(e) => { println!("{e}"); }
+    }
 
     // let mut parser = SubtitleParser::new();
 

--- a/src/types/srt_index.rs
+++ b/src/types/srt_index.rs
@@ -1,3 +1,4 @@
+use std::fmt::{write, Display};
 use std::str::FromStr;
 
 const PERMITTED_INDEX_CHARS: &str = "0123456789";
@@ -17,6 +18,22 @@ pub enum SrtIndexError {
     EmptyIndex,
     IndexExceedsMaxU32Size(String),
     IndexContainsDisallowedChars(String),
+}
+
+impl Display for SrtIndexError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SrtIndexError::EmptyIndex => {
+                write!(f, "SRT index (integer) is empty")
+            }
+            SrtIndexError::IndexExceedsMaxU32Size(string) => {
+                write!(f, "Index {string} exceeds max u32 size")
+            }
+            SrtIndexError::IndexContainsDisallowedChars(string) => {
+                write!(f, "Index {string} contains non-numeric characters")
+            }
+        }
+    }
 }
 
 // Implement Error trait and Display trait -- all error types should both traits.

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -38,10 +38,10 @@ impl Display for TimestampError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             TimestampError::EmptyString => {
-                write!(f, "Timestamp string should not be empty")
+                write!(f, "timestamp string should not be empty")
             }
             TimestampError::MalformedTimestamp(s) => {
-                write!(f, "{}", format!("Malformed timestamp: {s}"))
+                write!(f, "{}", format!("malformed timestamp: {s}"))
             }
         }
     }

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -18,7 +18,7 @@ pub struct Timestamp {
 
 impl Display for Timestamp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}:{:02}:{:02} {:03}", self.hours, self.minutes, self.seconds, self.milliseconds)
+        write!(f, "{}:{:02}:{:02} {:03} (hours:minutes:seconds milliseconds)", self.hours, self.minutes, self.seconds, self.milliseconds)
     }
 }
 

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+use std::fmt::Display;
 use std::str::FromStr;
 
 const PERMITTED_TIMESTAMP_CHARS: &str = "0123456789:,";
@@ -14,6 +16,12 @@ pub struct Timestamp {
     pub milliseconds: u16,
 }
 
+impl Display for Timestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{:02}:{:02} {:03}", self.hours, self.minutes, self.seconds, self.milliseconds)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TimestampError {
     EmptyString,
@@ -25,6 +33,21 @@ impl TimestampError {
         TimestampError::MalformedTimestamp(format!("{} (input string: {})", msg, original_input))
     }
 }
+
+impl Display for TimestampError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TimestampError::EmptyString => {
+                write!(f, "Timestamp string should not be empty")
+            }
+            TimestampError::MalformedTimestamp(s) => {
+                write!(f, "{}", format!("Malformed timestamp: {s}"))
+            }
+        }
+    }
+}
+
+impl Error for TimestampError {}
 
 impl FromStr for Timestamp {
     type Err = TimestampError;
@@ -39,12 +62,12 @@ impl FromStr for Timestamp {
             return Err(TimestampError::EmptyString);
         } else if count_char_occurrences(s, ',') != 1 {
             return Err(TimestampError::malformed(
-                "Timestamp string can’t have more than one comma as a millisecond separator",
+                "timestamp string can’t have multiple commas as a millisecond separator",
                 s,
             ));
         } else if s.contains("\n") {
             return Err(TimestampError::malformed(
-                "Timestamp string cannot contain newlines",
+                "timestamp string cannot contain newlines",
                 s,
             ));
         } else if s
@@ -53,7 +76,7 @@ impl FromStr for Timestamp {
             == false
         {
             return Err(TimestampError::malformed(
-                "Illegal characters detected; allowed characters are 0123456789:,",
+                "illegal characters detected; allowed characters are 0123456789:,",
                 s,
             ));
         }
@@ -66,7 +89,7 @@ impl FromStr for Timestamp {
         let split_hh_mm_ss: Vec<&str> = raw_hh_mm_ss.split(":").collect();
         if split_hh_mm_ss.len() != 3 {
             return Err(TimestampError::malformed(
-                "Timestamp must have properly defined HH:MM:SS component",
+                "timestamp must have properly defined HH:MM:SS component",
                 s,
             ));
         }
@@ -76,27 +99,27 @@ impl FromStr for Timestamp {
         let raw_ss = split_hh_mm_ss[2];
         if raw_hh.is_empty() {
             return Err(TimestampError::malformed(
-                "Empty hours value in HH:MM:SS",
+                "empty hours value in HH:MM:SS",
                 s,
             ));
         } else if raw_mm.is_empty() {
             return Err(TimestampError::malformed(
-                "Empty minutes value in HH:MM:SS",
+                "empty minutes value in HH:MM:SS",
                 s,
             ));
         } else if raw_ss.is_empty() {
             return Err(TimestampError::malformed(
-                "Empty seconds value in HH:MM:SS",
+                "empty seconds value in HH:MM:SS",
                 s,
             ));
         }
 
         let raw_ms = split_on_comma[1];
         if raw_ms.is_empty() {
-            return Err(TimestampError::malformed("Empty milliseconds value", s));
+            return Err(TimestampError::malformed("empty milliseconds value", s));
         } else if count_char_occurrences(raw_ms, ':') > 0 {
             return Err(TimestampError::malformed(
-                "Milliseconds component contains illegal colon character",
+                "milliseconds component contains illegal colon character",
                 s,
             ));
         }
@@ -105,38 +128,38 @@ impl FromStr for Timestamp {
         if hours > U8_MAX_255 {
             // Should I increase the allocation to u16?
             return Err(TimestampError::malformed(
-                "Hours value exceeds maximum unsigned 8-bit value of 255",
+                "hours value exceeds maximum unsigned 8-bit value of 255",
                 s,
             ));
         }
         let minutes = raw_mm.parse::<usize>().unwrap();
         if minutes > U8_MAX_255 {
             return Err(TimestampError::malformed(
-                "Minutes value exceeds maximum unsigned 8-bit value of 255",
+                "minutes value exceeds maximum unsigned 8-bit value of 255",
                 s,
             ));
         } else if minutes > 59 {
-            return Err(TimestampError::malformed("Minutes value exceeds 59", s));
+            return Err(TimestampError::malformed("minutes value exceeds 59", s));
         }
         let seconds = raw_ss.parse::<usize>().unwrap();
         if seconds > U8_MAX_255 {
             return Err(TimestampError::malformed(
-                "Seconds value exceeds maximum unsigned 8-bit value of 255",
+                "seconds value exceeds maximum unsigned 8-bit value of 255",
                 s,
             ));
         } else if seconds > 59 {
-            return Err(TimestampError::malformed("Seconds value exceeds 59", s));
+            return Err(TimestampError::malformed("seconds value exceeds 59", s));
         }
         let milliseconds = raw_ms.parse::<usize>().unwrap();
         if milliseconds > U16_MAX_65535 {
-            println!("Regarding timestamp string: {}", s);
+            println!("regarding timestamp string: {}", s);
             return Err(TimestampError::malformed(
-                "Milliseconds value exceeds maximum unsigned 16-bit value of 65535",
+                "milliseconds value exceeds maximum unsigned 16-bit value of 65535",
                 s,
             ));
         } else if milliseconds > 999 {
             return Err(TimestampError::malformed(
-                "Milliseconds value exceeds 999",
+                "milliseconds value exceeds 999",
                 s,
             ));
         }

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -152,7 +152,6 @@ impl FromStr for Timestamp {
         }
         let milliseconds = raw_ms.parse::<usize>().unwrap();
         if milliseconds > U16_MAX_65535 {
-            println!("regarding timestamp string: {}", s);
             return Err(TimestampError::malformed(
                 "milliseconds value exceeds maximum unsigned 16-bit value of 65535",
                 s,

--- a/src/types/timing.rs
+++ b/src/types/timing.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+use std::fmt::{Display, Formatter};
 use crate::types::timestamp;
 use crate::types::timestamp::{Timestamp, TimestampError};
 use std::str::FromStr;
@@ -15,6 +17,12 @@ pub struct Timing {
     pub end: Timestamp,
 }
 
+impl Display for Timing {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} -> {}", self.start, self.end)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TimingError {
     EmptyTiming,
@@ -27,6 +35,24 @@ impl TimingError {
         TimingError::MalformedTiming(format!("{} (input: {})", msg, original_input))
     }
 }
+
+impl Display for TimingError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TimingError::EmptyTiming => {
+                write!(f, "timing string should not be empty")
+            }
+            TimingError::MalformedTiming(s) => {
+                write!(f, "{}", format!("malformed timing: {s}"))
+            }
+            TimingError::Timestamp(s) => {
+                write!(f, "{}", format!("timestamp error: {s}"))
+            }
+        }
+    }
+}
+
+impl Error for TimingError {}
 
 impl From<TimestampError> for TimingError {
     // This allows me to convert a `TimestampError` to a `TimingError` using the `parse` function. Although
@@ -51,11 +77,11 @@ impl FromStr for Timing {
 
         if split_s_elems == 1 {
             return Err(TimingError::malformed(
-                "Missing timestamp separator (-->)",
+                "missing timestamp separator (-->)",
                 s,
             ));
         } else if split_s_elems > 2 {
-            return Err(TimingError::malformed("Multiple timestamp separators", s));
+            return Err(TimingError::malformed("multiple timestamp separators", s));
         }
 
         let start_raw: &str = split_s_collected[0].trim();
@@ -66,7 +92,7 @@ impl FromStr for Timing {
 
         if start_timestamp > end_timestamp {
             return Err(TimingError::malformed(
-                "Start timestamp is later than end timestamp",
+                "start timestamp is later than end timestamp",
                 s,
             ));
         }
@@ -104,12 +130,12 @@ mod tests {
         let input = "00:18:25,437 00:18:27,439";
         let result = input.parse::<Timing>();
         let expected_error_msg =
-            "Missing timestamp separator (-->) (input: 00:18:25,437 00:18:27,439)";
+            "missing timestamp separator (-->) (input: 00:18:25,437 00:18:27,439)";
 
         assert!(result.is_err());
         match result.unwrap_err() {
             TimingError::MalformedTiming(msg) => assert_eq!(msg, expected_error_msg),
-            _ => panic!("Expected this error message: Missing timestamp separator (-->)"),
+            _ => panic!("Expected this error message: missing timestamp separator (-->)"),
         }
     }
 }

--- a/src/types/timing.rs
+++ b/src/types/timing.rs
@@ -1,3 +1,4 @@
+use std::fmt::Display;
 use crate::types::timestamp;
 use crate::types::timestamp::{Timestamp, TimestampError};
 use std::str::FromStr;
@@ -25,6 +26,22 @@ pub enum TimingError {
 impl TimingError {
     pub fn malformed(msg: &str, original_input: &str) -> Self {
         TimingError::MalformedTiming(format!("{} (input: {})", msg, original_input))
+    }
+}
+
+impl Display for TimingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TimingError::EmptyTiming => {
+                write!(f, "No start and end timestamps found")
+            }
+            TimingError::MalformedTiming(string) => {
+                write!(f, "Malformed timing string: {string}")
+            }
+            TimingError::Timestamp(timestamp_error) => {
+                write!(f, "{timestamp_error}")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Implement `Display` for:

- [x] `TimestampError`
- [x] `SrtIndexError`
- [x] `TimingError`
- [x] `ParserError`